### PR TITLE
Add event handler to update postion on mouse wheel events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-input-position",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-input-position",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "A React component that decorates it's children with mouse/touch position tracking, a status toggle fired by click/gesture events, and more.",
   "keywords": [
     "touch",

--- a/src/mouseActivation/click.js
+++ b/src/mouseActivation/click.js
@@ -35,10 +35,16 @@ function mouseLeave() {
   this.mouseDown = false;
 }
 
+function wheel(e) {
+  const position = { x: e.clientX, y: e.clientY };
+  this.setPosition(position);
+}
+
 export default {
   mouseDown,
   mouseUp,
   mouseMove,
   mouseLeave,
+  wheel,
   dragStart: utils.preventDefault
 };

--- a/src/mouseActivation/doubleClick.js
+++ b/src/mouseActivation/doubleClick.js
@@ -28,11 +28,17 @@ function mouseLeave() {
   this.mouseDown = false;
 }
 
+function wheel(e) {
+  const position = { x: e.clientX, y: e.clientY };
+  this.setPosition(position);
+}
+
 export default {
   mouseDown,
   mouseUp,
   dblClick,
   mouseMove,
   mouseLeave,
+  wheel,
   dragStart: utils.preventDefault
 };

--- a/src/mouseActivation/hover.js
+++ b/src/mouseActivation/hover.js
@@ -28,11 +28,17 @@ function mouseLeave() {
   this.mouseDown = false;
 }
 
+function wheel(e) {
+  const position = { x: e.clientX, y: e.clientY };
+  this.setPosition(position);
+}
+
 export default {
   mouseDown,
   mouseUp,
   mouseMove,
   mouseEnter,
   mouseLeave,
+  wheel,
   dragStart: utils.preventDefault
 };

--- a/src/mouseActivation/mouseDown.js
+++ b/src/mouseActivation/mouseDown.js
@@ -55,11 +55,17 @@ function addRemoveOutsideHandlers(add) {
     });
 }
 
+function wheel(e) {
+  const position = { x: e.clientX, y: e.clientY };
+  this.setPosition(position);
+}
+
 export default {
   mouseDown,
   mouseUp,
   mouseMove,
   mouseLeave,
   mouseEnter,
+  wheel,
   dragStart: utils.preventDefault
 };


### PR DESCRIPTION
Hello!
I am working on a project where we use this library to implement image magnifying but with the ability to zoom in/out using the mouse wheel. For that I need updates on the item position when the mouse wheel is used, my pull request implements this and fits my requirements.
Do you see any problems with this? If not, I'd be happy to see this merged into your library & pushed to npm.
Thanks and kind regards,
Florian

Edit: I just saw that the current implementation, that I am working on, is a fork of your Side-By-Side magnifier with the possibility to use the scroll wheel (-> the SideBySideMagnifier has a scale property which is set from outside on wheel events) so you know which problem I am trying to solve with this.